### PR TITLE
Remove unused tkinter import to eliminate dependency

### DIFF
--- a/source/patchbay/patchcanvas/connectable_widget.py
+++ b/source/patchbay/patchcanvas/connectable_widget.py
@@ -1,6 +1,5 @@
 
 import time
-from tkinter import N
 from typing import TYPE_CHECKING, Optional
 from qtpy.QtCore import Qt, QPointF
 from qtpy.QtGui import QCursor


### PR DESCRIPTION
I noticed that the line:

```
from tkinter import N
```

is present in the code but N isn't used anywhere. I see this is the only reference to `tkinter`, and I think that it can be safely removed to eliminate the unnecessary dependency on the `tkinter` module.

This would help simplify the project's dependencies slightly, especially for environments where `tkinter` may not be available by default. For example, on Gentoo, Python is compiled without Tk support by default.