### PR TITLE
Fix QColor::fromRgb: RGB parameters out of range warnings when DSP load exceeds 100%

### DIFF
--- a/source/patchbay/surclassed_widgets.py
+++ b/source/patchbay/surclassed_widgets.py
@@ -47,8 +47,9 @@ class ProgressBarDsp(QProgressBar):
         QProgressBar.__init__(self)
 
     def setValue(self, value: int):
-        color_border = "rgba(%i%%, %i%%, 0, 55%%)" % (value, 100 - value)
-        color_center = "rgba(%i%%, %i%%, 0, 45%%)" % (value, 100 - value)
+        v = max(0, min(100, value))
+        color_border = "rgba(%i%%, %i%%, 0, 55%%)" % (v, 100 - v)
+        color_center = "rgba(%i%%, %i%%, 0, 45%%)" % (v, 100 - v)
         self.setStyleSheet(
             "QProgressBar:chunk{background-color: "
             + "qlineargradient(x1:0, y1:0, x2:0, y1:1, "


### PR DESCRIPTION
Hey guys, hope you're doing well.

When the JACK DSP load goes above 100% (e.g. during xruns or transient overloads), ProgressBarDsp.setValue receives a value greater than 100. The CSS gradient color computation 100 - value then produces a negative percentage, which Qt rejects with:

> QColor::fromRgb: RGB parameters out of range


Since the gradient has 3 color stops, this fires 3 times per DSP update cycle, flooding the journal during any overload.

Fix: clamp the value to [0, 100] before computing the gradient colors. The raw value is still passed to QProgressBar.setValue so the bar widget itself can reflect the over-100% state correctly.

```python
v = max(0, min(100, value))
color_border = "rgba(%i%%, %i%%, 0, 55%%)" % (v, 100 - v)
color_center = "rgba(%i%%, %i%%, 0, 45%%)" % (v, 100 - v)
```

Thanks in advance,