### PR TITLE
Fix connections not drawn when second port arrives after connection registered

### DIFF
--- a/source/patchbay/bases/port.py
+++ b/source/patchbay/bases/port.py
@@ -188,6 +188,7 @@ class Port:
 
             for conn in visible_conns:
                 self.set_hidden_conn_in_canvas(conn, False)
+                conn.add_to_canvas()
 
             if self.conns_hidden_in_canvas:
                 patchcanvas.port_has_hidden_connection(


### PR DESCRIPTION
When add_connection() fires before one port is in the canvas, the connection is stored as hidden on both ports. 
When the late port is finally added to the canvas, visible_conns were correctly cleared from the hidden sets but conn.add_to_canvas() was never called, leaving the line undrawn until a manual canvas refresh.

Tested on Fedora 44.